### PR TITLE
chore: cleanup test dependencies, remove cubertura

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.java]
+indent_size = 4
+
+[*.{yml, yaml, conf, json, avsc}]
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,3 @@ dist: xenial
 jdk:
 - openjdk8
 
-script: "mvn cobertura:cobertura"
-
-after_success:
-- bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-[![Build Status](https://travis-ci.org/artur-tamazian/avro-schema-generator.svg?branch=master)](https://travis-ci.org/artur-tamazian/avro-schema-generator)
-[![Coverage](https://codecov.io/gh/artur-tamazian/avro-schema-generator/branch/master/graph/badge.svg)](https://codecov.io/gh/artur-tamazian/avro-schema-generator)
-[![Join the chat at https://gitter.im/avro-schema-generator](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/avro-schema-generator?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://img.shields.io/travis/artur-tamazian/avro-schema-generator/master?logo=travis&style=for-the-badge)](https://travis-ci.org/artur-tamazian/avro-schema-generator)
+[![Chat in Gitter](https://img.shields.io/gitter/room/artur-tamazian/avro-schema-generator?logo=gitter&style=for-the-badge)](https://gitter.im/avro-schema-generator/Lobby)
 
 # avro-schema-generator
 Library for generating avro schema files (.avsc) based on DB tables structure.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.github.artur-tamazian</groupId>
@@ -11,13 +12,14 @@
     <url>https://github.com/artur-tamazian/avro-schema-generator</url>
 
     <properties>
-        <schemacrawler.version>16.2.1</schemacrawler.version>
+        <schemacrawler.version>16.2.4</schemacrawler.version>
         <modeshape-common.version>5.3.0.Final</modeshape-common.version>
         <spring-jdbc.version>4.2.0.RELEASE</spring-jdbc.version>
         <mockito.version>3.1.0</mockito.version>
         <junit.version>4.12</junit.version>
         <hsqldb.version>2.3.2</hsqldb.version>
         <commons-io.version>2.5</commons-io.version>
+        <testcontainers.version>1.12.3</testcontainers.version>
     </properties>
 
     <build>
@@ -70,7 +72,7 @@
                         <format>html</format>
                         <format>xml</format>
                     </formats>
-                    <check />
+                    <check/>
                 </configuration>
             </plugin>
             <plugin>
@@ -137,7 +139,7 @@
     <dependencies>
         <dependency>
             <groupId>us.fatehi</groupId>
-            <artifactId>schemacrawler-mysql</artifactId>
+            <artifactId>schemacrawler</artifactId>
             <version>${schemacrawler.version}</version>
         </dependency>
 
@@ -162,13 +164,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
@@ -181,6 +176,21 @@
             <version>${commons-io.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <licenses>


### PR DESCRIPTION
- removed explicit junit, transitively provided
- removed schema crawler mysql from main dependencies
- added testcontainers for future usage in intregraion tests
- removed cobertura, it's stopping migration to recent JVM
- removed cobertura since cobertura task ignores results of tests
- improving README badges

this is a preparation for #7 