### PR TITLE
Move table name filtering to the server (db) side.

### DIFF
--- a/src/test/java/com/at/avro/integration/PgsqlIntegrationTest.java
+++ b/src/test/java/com/at/avro/integration/PgsqlIntegrationTest.java
@@ -11,6 +11,9 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 
+import java.util.Comparator;
+import java.util.List;
+
 import static helper.Utils.classPathResourceContent;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -38,7 +41,7 @@ public class PgsqlIntegrationTest {
     }
 
     @Test
-    public void testDefaultTabe() {
+    public void testDefaultTable() {
         AvroSchema avroSchema = extractor.getForTable(avroConfig, null, "default_table");
         assertThat(SchemaGenerator.generate(avroSchema), is(classPathResourceContent("/pgsql/avro/default_table.avsc")));
     }
@@ -48,12 +51,19 @@ public class PgsqlIntegrationTest {
         AvroSchema avroSchema = extractor.getForTable(avroConfig, null, "array_table");
         assertThat(SchemaGenerator.generate(avroSchema), is(classPathResourceContent("/pgsql/avro/array_table.avsc")));
     }
-    
+
     @Test
     public void testDefaultTableWithDoc() {
         avroConfig.setUseSqlCommentsAsDoc(true);
         AvroSchema avroSchema = extractor.getForTable(avroConfig, null, "comment_table");
         assertThat(SchemaGenerator.generate(avroSchema), is(classPathResourceContent("/pgsql/avro/comment_table.avsc")));
-        
+    }
+
+    @Test
+    public void testMultipleTables() {
+        List<AvroSchema> schemas = extractor.getForTables(avroConfig, null, "default_table", "comment_table", "array_table");
+        assertThat(schemas.size(), is(3));
+        AvroSchema arrayTableSchema = schemas.stream().sorted(Comparator.comparing(schema -> schema.getName())).findFirst().get();
+        assertThat(arrayTableSchema.getFields().size(), is(7));
     }
 }


### PR DESCRIPTION
This is needed to speed up filtering by table name when we're only interested in a small subset of a large number of tables in the db.