### PR TITLE
feat: support pg timestamptz type

### DIFF
--- a/src/main/java/com/at/avro/AvroTypeUtil.java
+++ b/src/main/java/com/at/avro/AvroTypeUtil.java
@@ -34,7 +34,7 @@ final class AvroTypeUtil {
         else if (asList("decimal", "numeric").contains(type)) {
             return new AvroType(new Decimal(column, config), nullable);
         }
-        else if (asList("timestamp", "datetime", "date", "time").contains(type)) {
+        else if (asList("timestamptz", "timestamp", "datetime", "date", "time").contains(type)) {
             return new AvroType(new Date(column, config), nullable);
         } else if (typeClz == java.sql.Array.class) {
             return new AvroType(new Array(new Primitive(getPrimitiveType(type.substring(1), config))), nullable);

--- a/src/test/java/com/at/avro/AvroTypeUtilTest.java
+++ b/src/test/java/com/at/avro/AvroTypeUtilTest.java
@@ -77,7 +77,7 @@ public class AvroTypeUtilTest {
 
     @Test
     public void testDateTypes() throws Exception {
-        String[] dateTypes = new String[] { "date", "time", "datetime", "timestamp" };
+        String[] dateTypes = new String[] { "date", "time", "datetime", "timestamp", "timestamptz" };
 
         for (String dateType : dateTypes) {
             AvroType avroType = AvroTypeUtil.getAvroType(column(dateType), defaultConfig());

--- a/src/test/resources/pgsql/avro/default_table.avsc
+++ b/src/test/resources/pgsql/avro/default_table.avsc
@@ -11,6 +11,7 @@
     { "name": "created", "type": { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } },
     { "name": "updated", "type": [ "null", { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } ] },
     { "name": "decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 20, "scale": 3 } ] },
-    { "name": "other_decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 131089, "scale": 0 } ] }
+    { "name": "other_decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 131089, "scale": 0 } ] },
+    { "name": "cancelled", "type": [ "null", { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } ] }
   ]
 }

--- a/src/test/resources/pgsql/db/migration/V1__Create_default_table.sql
+++ b/src/test/resources/pgsql/db/migration/V1__Create_default_table.sql
@@ -7,5 +7,6 @@ create table default_table
     "created"             timestamp   not null,
     "updated"             timestamp,
     "decimal_field"       decimal(20, 3),
-    "other_decimal_field" decimal
+    "other_decimal_field" decimal,
+    "cancelled"           timestamp with time zone
 );


### PR DESCRIPTION
Postgres has a type `timestamptz` to support timestamps with user defined timezone, this type was not detected as an avro timestamp millis type (only the default `timestamp without timezone`).