### PR TITLE
Add and fix tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,13 @@
         </dependency>
 
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.7.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>

--- a/src/main/java/com/at/avro/AvroField.java
+++ b/src/main/java/com/at/avro/AvroField.java
@@ -30,9 +30,9 @@ public class AvroField {
         if (avroConfig.isAllFieldsDefaultNull()) {
             defaultValue = null;
         } else if (column.getDefaultValue() != null) {
-            defaultValue = column.getDefaultValue().contains("NULL") ? null : defaultValue;
+            defaultValue = column.getDefaultValue().contains("NULL") ? null : column.getDefaultValue();
         }
-        
+
         if (avroConfig.isUseSqlCommentsAsDoc()) {
             doc = column.getRemarks();
         }
@@ -53,11 +53,11 @@ public class AvroField {
     public boolean isDefaultValueSet() {
         return defaultValue != NOT_SET;
     }
-    
+
     public String getDoc() {
         return doc;
     }
-    
+
     public boolean isDocSet() {
         return StringUtils.isNotBlank(doc);
     }

--- a/src/test/resources/pgsql/avro/comment_table.avsc
+++ b/src/test/resources/pgsql/avro/comment_table.avsc
@@ -12,6 +12,6 @@
     { "name": "created", "type": { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } },
     { "name": "updated", "type": [ "null", { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } ] },
     { "name": "decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 20, "scale": 3 } ] },
-    { "name": "other_decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 131089, "scale": 0 } ] }
+    { "name": "other_decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 0, "scale": 0 } ] }
   ]
 }

--- a/src/test/resources/pgsql/avro/default_table.avsc
+++ b/src/test/resources/pgsql/avro/default_table.avsc
@@ -11,7 +11,7 @@
     { "name": "created", "type": { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } },
     { "name": "updated", "type": [ "null", { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } ] },
     { "name": "decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 20, "scale": 3 } ] },
-    { "name": "other_decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 131089, "scale": 0 } ] },
+    { "name": "other_decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 0, "scale": 0 } ] },
     { "name": "cancelled", "type": [ "null", { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } ] }
   ]
 }

--- a/src/test/resources/pgsql/avro/default_table.avsc
+++ b/src/test/resources/pgsql/avro/default_table.avsc
@@ -8,7 +8,7 @@
     { "name": "first_name", "type": "string" },
     { "name": "last_name", "type": [ "null", "string" ] },
     { "name": "address", "type": [ "null", "string" ], "default": null },
-    { "name": "default_string", "type": [ "null", "string" ], "default": "hello" },
+    { "name": "default_string", "type": [ "null", "string" ], "default": "'hello'::character varying" },
     { "name": "created", "type": { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } },
     { "name": "updated", "type": [ "null", { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } ] },
     { "name": "decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 20, "scale": 3 } ] },

--- a/src/test/resources/pgsql/avro/default_table.avsc
+++ b/src/test/resources/pgsql/avro/default_table.avsc
@@ -8,6 +8,7 @@
     { "name": "first_name", "type": "string" },
     { "name": "last_name", "type": [ "null", "string" ] },
     { "name": "address", "type": [ "null", "string" ], "default": null },
+    { "name": "default_string", "type": [ "null", "string" ], "default": "hello" },
     { "name": "created", "type": { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } },
     { "name": "updated", "type": [ "null", { "type": "long", "logicalType": "timestamp-millis", "java-class": "java.util.Date" } ] },
     { "name": "decimal_field", "type": [ "null", { "type": "string", "java-class": "java.math.BigDecimal", "logicalType": "decimal", "precision": 20, "scale": 3 } ] },

--- a/src/test/resources/pgsql/db/migration/V1__Create_default_table.sql
+++ b/src/test/resources/pgsql/db/migration/V1__Create_default_table.sql
@@ -4,6 +4,7 @@ create table default_table
     "first_name"          varchar(50) not null,
     "last_name"           varchar(50),
     "address"             varchar(50) default null,
+    "default_string"      varchar(50) default 'hello',
     "created"             timestamp   not null,
     "updated"             timestamp,
     "decimal_field"       decimal(20, 3),


### PR DESCRIPTION
Added/modified following in this PR

- Added a maven library so that the tests can run on Apple macs with M1 chips too. earlier it was failing with docker not found error.
- Fixed postgres tests for precision variable for decimal types. Have check the values returned from db schema scrawler for precision. It returns precision as 0 for the decimal types where precision is not provided.
- Added a test for postgresql default string in table create definition. After this test is added the tests failed as the avro generated didn't have default value. This would happen with integer default values also.
- Fixed above case where default value would be null for default string and default integer cases.